### PR TITLE
Correct minor typos throughout the client

### DIFF
--- a/AndroidCll/src/main/java/com/microsoft/cll/android/AndroidPartA.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/AndroidPartA.java
@@ -69,7 +69,7 @@ public class AndroidPartA extends PartA {
     }
 
     /**
-     * Sets the device unique id using a has of either the device id if present or the mac address.
+     * Sets the device unique id using a hash of either the device id if present or the mac address.
      * Also sets the os version and the locale
      */
     @Override

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/Cll.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/Cll.java
@@ -79,8 +79,8 @@ public class Cll implements IChannel, ICll
     }
 
     @Override
-    public void useLagacyCS(boolean value) {
-        cll.useLagacyCS(value);
+    public void useLegacyCS(boolean value) {
+        cll.useLegacyCS(value);
     }
 
     @Override

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/CllSettings.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/CllSettings.java
@@ -23,7 +23,7 @@ public class CllSettings extends AbstractSettings
     }
 
     /**
-     *Parses the settings returned from OneSettings
+     * Parses the settings returned from OneSettings
      */
     @Override
     public void ParseSettings(JSONObject resultJson)

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/EventHandler.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/EventHandler.java
@@ -51,7 +51,7 @@ public class EventHandler extends ScheduledWorker
     }
 
     /**
-    Timed queue drain
+     * Timed queue drain
      */
     @Override
     public void run()
@@ -81,7 +81,7 @@ public class EventHandler extends ScheduledWorker
     }
 
     /**
-     * log an item to it's appropriate storage or attempt to send the event immediately if it is real time
+     * log an item to its appropriate storage or attempt to send the event immediately if it is real time
      * @param event The event to store and send
      * @return True if we added the event to the queue or False if we couldn't add the event
      */
@@ -195,7 +195,7 @@ public class EventHandler extends ScheduledWorker
     //endregion
 
     /**
-     * * Drains the critical event queue and then the normal and sends the events
+     * Drains the critical event queue and then the normal and sends the events
      * @return returns false if paused, otherwise true
      */
     protected boolean send() {

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/EventQueueWriter.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/EventQueueWriter.java
@@ -234,7 +234,7 @@ public class EventQueueWriter implements Runnable {
      * Generates a random backoff interval using k*b^p.
      * k is a constant we multiply by
      * b is the base which we raise to a power
-     * p is the power we raise to. where p is between 0..n where n increases everytime we fail unless increaseing it would put us over the maxretryperiod.
+     * p is the power we raise to. where p is between 0..n where n increases every time we fail unless increasing it would put us over the maxretryperiod.
      * @return A retry interval
      */
     int generateBackoffInterval() {

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/FileStorage.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/FileStorage.java
@@ -31,7 +31,7 @@ public class FileStorage implements IStorage {
     private AbstractHandler parent;
 
     /**
-    This constructor is for opening a new file.
+     * This constructor is for opening a new file.
      */
     public FileStorage(String fileExtension, ILogger logger, String filePath, AbstractHandler parent) {
         this.eventsWritten      = 0;

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/FileStorage.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/FileStorage.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * Storage for events on disk
  */
 public class FileStorage implements IStorage {
-    protected static final SyncronizedArrayList<String> fileLockList = new SyncronizedArrayList<String>();
+    protected static final SynchronizedArrayList<String> fileLockList = new SynchronizedArrayList<String>();
     private final String TAG = "FileStorage";
     private final ILogger logger;
     private final EventSerializer serializer;

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/HostSettings.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/HostSettings.java
@@ -18,7 +18,7 @@ public class HostSettings extends AbstractSettings {
     }
 
     /*
-    Parses the settings returned by OneSettings
+     * Parses the settings returned by OneSettings
      */
     @Override
     public void ParseSettings(JSONObject resultJson) {
@@ -52,7 +52,7 @@ public class HostSettings extends AbstractSettings {
     }
 
     /*
-    Sets the endpoint for where to look for this apps settings.
+     * Sets the endpoint for where to look for this app's settings.
      */
     @Override
     public void setSettingsEndpoint(String iKey) {

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/ICll.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/ICll.java
@@ -75,10 +75,10 @@ public interface ICll {
     void setEndpointUrl(final String url);
 
     /**
-     * Set's whether we should use the legacy part A fields or not.
+     * Sets whether we should use the legacy part A fields or not.
      * @param value True if we should, false if we should not
      */
-    void useLagacyCS(boolean value);
+    void useLegacyCS(boolean value);
 
     /**
      * Sets the experiment id

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/ICll.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/ICll.java
@@ -4,9 +4,6 @@ import com.microsoft.telemetry.Base;
 
 import java.util.Map;
 
-/**
- * Created by jmorman on 7/14/2015.
- */
 public interface ICll {
     /**
      * Starts the queue-draining background thread and uploader. Start must be called prior

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/PartA.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/PartA.java
@@ -52,7 +52,7 @@ public abstract class PartA {
     private long epoch;
     private long flags;
     private String iKey;
-    private boolean useLagacyCS = false;
+    private boolean useLegacyCS = false;
 
     /**
      * Set variables that will be used across all Part A's and constant
@@ -85,7 +85,7 @@ public abstract class PartA {
         Cll.EventPersistence persistence = Cll.EventPersistence.valueOf(SettingsStore.getSetting(base, SettingsStore.Settings.PERSISTENCE).toString().toUpperCase());
         Cll.EventLatency latency = Cll.EventLatency.valueOf(SettingsStore.getSetting(base, SettingsStore.Settings.LATENCY).toString().toUpperCase());
 
-        if(useLagacyCS) {
+        if(useLegacyCS) {
             com.microsoft.telemetry.cs2.Envelope envelope = populateLegacyEnvelope(base, cV, sampleRate, persistence, latency, tags);
             return populateSerializedEvent(serializer.serialize(envelope), persistence, latency, envelope.getSampleRate(), envelope.getDeviceId());
         } else {
@@ -140,11 +140,11 @@ public abstract class PartA {
     }
 
     /**
-     * Set's whether we should use the legacy part A fields or not.
+     * Sets whether we should use the legacy part A fields or not.
      * @param value True if we should, false if we should not
      */
-    void useLagacyCS(boolean value) {
-        this.useLagacyCS = value;
+    void useLegacyCS(boolean value) {
+        this.useLegacyCS = value;
     }
 
     protected abstract void setDeviceInfo();

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/ScheduledWorker.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/ScheduledWorker.java
@@ -27,7 +27,7 @@ public abstract class ScheduledWorker implements Runnable{
     }
 
     protected void stop() {
-        // Cancels the current even if in progress.
+        // Cancels the current sync even if in progress.
         nextExecution.cancel(true);
     }
 

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/SingletonCll.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/SingletonCll.java
@@ -230,11 +230,11 @@ public class SingletonCll implements ICll, IChannel {
     }
 
     /**
-     * Set's whether we should use the legacy part A fields or not.
+     * Sets whether we should use the legacy part A fields or not.
      * @param value True if we should, false if we should not
      */
-    public void useLagacyCS(boolean value) {
-        partA.useLagacyCS(value);
+    public void useLegacyCS(boolean value) {
+        partA.useLegacyCS(value);
     }
 
     /**

--- a/AndroidCll/src/main/java/com/microsoft/cll/android/SynchronizedArrayList.java
+++ b/AndroidCll/src/main/java/com/microsoft/cll/android/SynchronizedArrayList.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 /**
  * A Synchronized array list
  */
-public class SyncronizedArrayList<T> extends ArrayList<T>
+public class SynchronizedArrayList<T> extends ArrayList<T>
 {
     @Override
     public synchronized boolean add(T t) {

--- a/SharedTelemetryContracts/src/main/java/com/microsoft/telemetry/Base.java
+++ b/SharedTelemetryContracts/src/main/java/com/microsoft/telemetry/Base.java
@@ -31,7 +31,7 @@ public class Base implements
     public LinkedHashMap<String, String> Attributes = new LinkedHashMap<String, String>();
     
     /**
-     * The name for thie type
+     * The name for this type
      */
     public String QualifiedName;
     

--- a/SharedTelemetryContracts/src/main/java/com/microsoft/telemetry/Domain.java
+++ b/SharedTelemetryContracts/src/main/java/com/microsoft/telemetry/Domain.java
@@ -31,7 +31,7 @@ public class Domain implements
     public LinkedHashMap<String, String> Attributes = new LinkedHashMap<String, String>();
     
     /**
-     * The name for thie type
+     * The name for this type
      */
     public String QualifiedName;
     


### PR DESCRIPTION
Most notably `useLagacyCS()` -> `useLegacyCS()` and `SyncronizedArrayList` -> `SynchronizedArrayList`.
