### PR TITLE
Bumping minor version number because we changed a public facing api. …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 POM_NAME=Android CLL
 POM_ARTIFACT_ID=JLL
 POM_PACKAGING=aar
-VERSION_NAME=2.0.2
+VERSION_NAME=2.1.0
 
 
-projectVersion=2.0.2
+projectVersion=2.1.0
 projectGroup=com.github.microsoft.telemetry-client-for-android
 projectName=Telemetry-Client-For-Android
 projectDesc=Telemetry Client for Android for use by ApplicationInsights-Android


### PR DESCRIPTION
…(Fixed spelling of legacy in useLegacyCS). This change should only effect application insights.
